### PR TITLE
add namespace to all objects

### DIFF
--- a/charts/bee/Chart.yaml
+++ b/charts/bee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: latest
 name: bee
-version: 0.5.3
+version: 0.5.4
 description: Ethereum Swarm Bee Helm chart for Kubernetes
 home: https://swarm.ethereum.org
 icon: https://swarm-guide.readthedocs.io/en/latest/_images/swarm.png

--- a/charts/bee/README.md
+++ b/charts/bee/README.md
@@ -86,7 +86,7 @@ apps:
     namespace: bee
     description: "Ethereum Swarm Bee"
     chart: "ethersphere/bee"
-    version: "0.4.1"
+    version: "0.5.4"
     enabled: true
     set:
       beeConfig.bootnode: # bootnode multi address
@@ -118,7 +118,7 @@ apps:
     namespace: bee
     description: "Ethereum Swarm Bee"
     chart: "ethersphere/bee"
-    version: "0.4.1"
+    version: "0.5.4"
     enabled: true
     set:
       beeConfig.bootnode: "/dns4/bee-0-headless.bee.svc.cluster.local/tcp/7070/p2p/16Uiu2HAm6i4dFaJt584m2jubyvnieEECgqM2YMpQ9nusXfy8XFzL"

--- a/charts/bee/templates/config.yaml
+++ b/charts/bee/templates/config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "bee.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" . | nindent 4 }}
 data:

--- a/charts/bee/templates/ingress-debug.yaml
+++ b/charts/bee/templates/ingress-debug.yaml
@@ -14,6 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-{{ $i }}-debug
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
   {{- with $root.Values.ingressDebug.annotations }}

--- a/charts/bee/templates/ingress-debug.yaml
+++ b/charts/bee/templates/ingress-debug.yaml
@@ -14,7 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-{{ $i }}-debug
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $root.Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
   {{- with $root.Values.ingressDebug.annotations }}

--- a/charts/bee/templates/ingress.yaml
+++ b/charts/bee/templates/ingress.yaml
@@ -14,6 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
   {{- with $root.Values.ingress.annotations }}
@@ -63,6 +64,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-{{ $i }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
   {{- with $root.Values.ingress.annotations }}

--- a/charts/bee/templates/ingress.yaml
+++ b/charts/bee/templates/ingress.yaml
@@ -64,7 +64,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-{{ $i }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $root.Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
   {{- with $root.Values.ingress.annotations }}

--- a/charts/bee/templates/secrets.yaml
+++ b/charts/bee/templates/secrets.yaml
@@ -11,7 +11,7 @@ metadata:
 type: Opaque
 data:
     password: {{ include "bee.password" . | b64enc | quote }}
-    
+
 {{- end -}}
 {{- if and .Values.libp2pSettings.enabled -}}
 
@@ -29,5 +29,5 @@ stringData:
     {{- range $key, $val := .Values.libp2pSettings.libp2pKeys }}
     {{ $key }}: {{ $val }}
     {{- end }}
-    
+
 {{- end -}}

--- a/charts/bee/templates/secrets.yaml
+++ b/charts/bee/templates/secrets.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "bee.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" . | nindent 4 }}
 type: Opaque
@@ -19,6 +20,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "bee.fullname" . }}-libp2p
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/bee/templates/service-debug.yaml
+++ b/charts/bee/templates/service-debug.yaml
@@ -9,6 +9,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "bee.fullname" $root }}-{{ $i }}-debug
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
     pod: {{ include "bee.fullname" $root }}-{{ $i }}

--- a/charts/bee/templates/service-debug.yaml
+++ b/charts/bee/templates/service-debug.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "bee.fullname" $root }}-{{ $i }}-debug
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $root.Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
     pod: {{ include "bee.fullname" $root }}-{{ $i }}

--- a/charts/bee/templates/service-headless.yaml
+++ b/charts/bee/templates/service-headless.yaml
@@ -35,7 +35,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "bee.fullname" $root }}-{{ $i }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $root.Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
     pod: {{ include "bee.fullname" $root }}-{{ $i }}

--- a/charts/bee/templates/service-headless.yaml
+++ b/charts/bee/templates/service-headless.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "bee.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" . | nindent 4 }}
 spec:
@@ -34,6 +35,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "bee.fullname" $root }}-{{ $i }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
     pod: {{ include "bee.fullname" $root }}-{{ $i }}

--- a/charts/bee/templates/service-p2p.yaml
+++ b/charts/bee/templates/service-p2p.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "bee.fullname" $root }}-{{ $i }}-p2p
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
     pod: {{ include "bee.fullname" $root }}-{{ $i }}

--- a/charts/bee/templates/service-p2p.yaml
+++ b/charts/bee/templates/service-p2p.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "bee.fullname" $root }}-{{ $i }}-p2p
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $root.Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
     pod: {{ include "bee.fullname" $root }}-{{ $i }}

--- a/charts/bee/templates/service.yaml
+++ b/charts/bee/templates/service.yaml
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullName }}-{{ $i }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $root.Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
     pod: {{ $fullName }}-{{ $i }}

--- a/charts/bee/templates/service.yaml
+++ b/charts/bee/templates/service.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
 spec:
@@ -27,6 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullName }}-{{ $i }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" $root | nindent 4 }}
     pod: {{ $fullName }}-{{ $i }}

--- a/charts/bee/templates/serviceaccount.yaml
+++ b/charts/bee/templates/serviceaccount.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "bee.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "bee.labels" . | nindent 4 }}
 

--- a/charts/bee/templates/statefulset.yaml
+++ b/charts/bee/templates/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "bee.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bee.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Using `helm template --namespace example ...` doesn't include namespace into generated yaml.
Solution based on this https://github.com/Azure/aad-pod-identity/pull/741