### PR TITLE
fix libp2p and swarm keys setting if more then 10 keys

### DIFF
--- a/charts/bee/Chart.yaml
+++ b/charts/bee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 name: bee
-version: 0.5.13
+version: 0.5.14
 description: Ethereum Swarm Bee Helm chart for Kubernetes
 home: https://swarm.ethereum.org
 icon: https://swarm-guide.readthedocs.io/en/latest/_images/swarm.png

--- a/charts/bee/README.md
+++ b/charts/bee/README.md
@@ -86,7 +86,7 @@ apps:
     namespace: bee
     description: "Ethereum Swarm Bee"
     chart: "ethersphere/bee"
-    version: "0.5.13"
+    version: "0.5.14"
     enabled: true
     set:
       beeConfig.bootnode: # bootnode multi address
@@ -118,7 +118,7 @@ apps:
     namespace: bee
     description: "Ethereum Swarm Bee"
     chart: "ethersphere/bee"
-    version: "0.5.13"
+    version: "0.5.14"
     enabled: true
     set:
       beeConfig.bootnode: "/dns4/bee-0-headless.bee.svc.cluster.local/tcp/7070/p2p/16Uiu2HAm6i4dFaJt584m2jubyvnieEECgqM2YMpQ9nusXfy8XFzL"

--- a/charts/bee/templates/statefulset.yaml
+++ b/charts/bee/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
               export INDEX=$(echo $(hostname) | rev | cut -d'-' -f 1 | rev);
               mkdir -p /home/bee/.bee/keys;
               chown -R 999:999 /home/bee/.bee/keys;
-              export KEY=$(cat /tmp/bee/libp2p.map | grep bee-${INDEX} | cut -d' ' -f2);
+              export KEY=$(cat /tmp/bee/libp2p.map | grep bee-${INDEX}: | cut -d' ' -f2);
               if [ -z "${KEY}" ]; then exit 0; fi;
               printf '%s' "${KEY}" > /home/bee/.bee/keys/libp2p.key;
               echo 'node initialization done';
@@ -74,7 +74,7 @@ spec:
               export INDEX=$(echo $(hostname) | rev | cut -d'-' -f 1 | rev);
               mkdir -p /home/bee/.bee/keys;
               chown -R 999:999 /home/bee/.bee/keys;
-              export KEY=$(cat /tmp/bee/swarm.map | grep bee-${INDEX} | cut -d' ' -f2);
+              export KEY=$(cat /tmp/bee/swarm.map | grep bee-${INDEX}: | cut -d' ' -f2);
               if [ -z "${KEY}" ]; then exit 0; fi;
               printf '%s' "${KEY}" > /home/bee/.bee/keys/swarm.key;
               echo 'node initialization done';


### PR DESCRIPTION
There was a mistake in grep, if you define more then 10 keys there were issues with grep