### PR TITLE
Status probe

### DIFF
--- a/charts/bee/Chart.yaml
+++ b/charts/bee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 name: bee
-version: 0.6.1
+version: 0.6.2
 description: Ethereum Swarm Bee Helm chart for Kubernetes
 home: https://swarm.ethereum.org
 icon: https://swarm-guide.readthedocs.io/en/latest/_images/swarm.png

--- a/charts/bee/README.md
+++ b/charts/bee/README.md
@@ -86,7 +86,7 @@ apps:
     namespace: bee
     description: "Ethereum Swarm Bee"
     chart: "ethersphere/bee"
-    version: "0.6.1"
+    version: "0.6.2"
     enabled: true
     set:
       beeConfig.bootnode: # bootnode multi address
@@ -118,7 +118,7 @@ apps:
     namespace: bee
     description: "Ethereum Swarm Bee"
     chart: "ethersphere/bee"
-    version: "0.6.1"
+    version: "0.6.2"
     enabled: true
     set:
       beeConfig.bootnode: "/dns4/bee-0-headless.bee.svc.cluster.local/tcp/1634/p2p/16Uiu2HAm6i4dFaJt584m2jubyvnieEECgqM2YMpQ9nusXfy8XFzL"

--- a/charts/bee/templates/statefulset.yaml
+++ b/charts/bee/templates/statefulset.yaml
@@ -155,23 +155,35 @@ spec:
             httpGet:
               path: /health
               port: debug
-            initialDelaySeconds: 25
+            initialDelaySeconds: 5
           readinessProbe:
             httpGet:
               path: /readiness
               port: debug
-            initialDelaySeconds: 25
+            initialDelaySeconds: 5
+          startupProbe:
+            httpGet:
+              path: /health
+              port: debug
+            failureThreshold: 30
+            periodSeconds: 10
           {{- else }}
           livenessProbe:
             httpGet:
               path: /
               port: api
-            initialDelaySeconds: 25
+            initialDelaySeconds: 5
           readinessProbe:
             httpGet:
               path: /
               port: api
-            initialDelaySeconds: 25
+            initialDelaySeconds: 5
+          startupProbe:
+            httpGet:
+              path: /
+              port: api
+            failureThreshold: 30
+            periodSeconds: 10
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Initial start can take too long. In this way we will allow 300s for start, until liveness probe hits, but later liveness will check every 5s.