### PR TITLE
Add ethersphere helm repository

### DIFF
--- a/charts/bee/README.md
+++ b/charts/bee/README.md
@@ -5,6 +5,7 @@
 ## QuickStart
 
 ```bash
+$ helm repo add ethersphere https://ethersphere.github.io/helm
 $ helm install --generate-name ethersphere/bee
 ```
 


### PR DESCRIPTION
I found the helm repository only via detours. Maybe it's easier for the users when the repo is part of the quick start section.

