### PR TITLE
enable web3 on geth-swap, update removed arguments

### DIFF
--- a/charts/geth-swap/Chart.yaml
+++ b/charts/geth-swap/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/geth-swap/templates/statefulset.yaml
+++ b/charts/geth-swap/templates/statefulset.yaml
@@ -61,19 +61,19 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - geth
-            - --rpc
-            - --rpcaddr
+            - --http
+            - --http.addr
             - "0.0.0.0"
             - --allow-insecure-unlock
             - --http.api
-            - 'eth,net,personal'
+            - 'eth,net,personal,web3'
+            - --http.vhosts
+            - "*"
             - --ws
             - --ws.addr
             - "0.0.0.0"
             - --ws.api
-            - 'eth,net,personal'
-            - --rpcvhosts
-            - "*"
+            - 'eth,net,personal,web3'
             - --unlock={{ .Values.geth.genesis.validatorAddress }}
             - --password=/dev/null
             - --mine


### PR DESCRIPTION
* add web3 to rpc so `web3_clienVersion` works in ci environment
* remove usage of deprecated so this works with current version of geth