### PR TITLE
Gateway autobuy

### DIFF
--- a/charts/bee/Chart.yaml
+++ b/charts/bee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 name: bee
-version: 0.11.1
+version: 0.11.2
 kubeVersion: ">=1.15.0-0"
 description: Ethereum Swarm Bee Helm chart for Kubernetes
 home: https://www.ethswarm.org

--- a/charts/bee/README.md
+++ b/charts/bee/README.md
@@ -99,7 +99,7 @@ apps:
     namespace: bee
     description: "Ethereum Swarm Bee"
     chart: "ethersphere/bee"
-    version: "0.11.1"
+    version: "0.11.2"
     enabled: true
     set:
       beeConfig.bootnode: # bootnode multi address
@@ -131,7 +131,7 @@ apps:
     namespace: bee
     description: "Ethereum Swarm Bee"
     chart: "ethersphere/bee"
-    version: "0.11.1"
+    version: "0.11.2"
     enabled: true
     set:
       beeConfig.bootnode: "/dns4/bee-0-headless.bee.svc.cluster.local/tcp/1634/p2p/16Uiu2HAm6i4dFaJt584m2jubyvnieEECgqM2YMpQ9nusXfy8XFzL"

--- a/charts/bee/templates/statefulset.yaml
+++ b/charts/bee/templates/statefulset.yaml
@@ -272,8 +272,10 @@ spec:
               value: "8633"
             - name: BEE_API_URL 
               value: "http://localhost:1633"
+          {{- if .Values.gatewayProxy.autobuy.enabled }}
             - name: BEE_DEBUG_API_URL
               value: "http://localhost:1635"
+          {{- end }}
           {{- with .Values.gatewayProxy.envs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/bee/values.yaml
+++ b/charts/bee/values.yaml
@@ -385,8 +385,13 @@ gatewayProxy:
         paths: []
         tlsSecret: ""
     tls: false
-  # Environment variables for this gateway-proxy container
-  # You can use any of the kubernetes env syntax here
+  ## If enabled it will configure bee debug api endpoint BEE_DEBUG_API_URL
+  ## that is needed for autobuy to work
+  ## If enabled set POSTAGE_DEPTH and POSTAGE_AMOUNT
+  autobuy:
+    enabled: false
+  ## Environment variables for this gateway-proxy container
+  ## You can use any of the kubernetes env syntax here
   envs: []
   # - name: POSTAGE_DEPTH
   #   value: 20


### PR DESCRIPTION
If `BEE_DEBUG_API_URL` is configured `gateway-proxy` expects that autobuy is enabled and you cannot deploy it without stamps at all