### PR TITLE
add resource settings for sidecar containers

### DIFF
--- a/charts/bee/Chart.yaml
+++ b/charts/bee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 name: bee
-version: 0.11.8
+version: 0.11.9
 kubeVersion: ">=1.15.0-0"
 description: Ethereum Swarm Bee Helm chart for Kubernetes
 home: https://www.ethswarm.org

--- a/charts/bee/templates/statefulset.yaml
+++ b/charts/bee/templates/statefulset.yaml
@@ -180,8 +180,6 @@ spec:
             - containerPort: {{ int (split ":" .Values.beeConfig.p2p_addr )._1 }}
               name: p2p
               protocol: TCP
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.probesEnable }}
           {{- if .Values.beeConfig.debug_api_enable }}
             - containerPort: {{ int (split ":" .Values.beeConfig.debug_api_addr )._1 }}
@@ -210,6 +208,8 @@ spec:
             initialDelaySeconds: 20
           {{- end }}
           {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:

--- a/charts/bee/templates/statefulset.yaml
+++ b/charts/bee/templates/statefulset.yaml
@@ -180,6 +180,8 @@ spec:
             - containerPort: {{ int (split ":" .Values.beeConfig.p2p_addr )._1 }}
               name: p2p
               protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.probesEnable }}
           {{- if .Values.beeConfig.debug_api_enable }}
             - containerPort: {{ int (split ":" .Values.beeConfig.debug_api_addr )._1 }}
@@ -208,8 +210,6 @@ spec:
             initialDelaySeconds: 20
           {{- end }}
           {{- end }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
@@ -253,6 +253,8 @@ spec:
             - containerPort: 8550
               name: api
               protocol: TCP
+          resources:
+            {{- toYaml .Values.clefSettings.resources | nindent 12 }}
           volumeMounts:
             - name: clef
               mountPath: /app/data
@@ -289,6 +291,8 @@ spec:
             - containerPort: 8633
               name: gateway-proxy
               protocol: TCP
+          resources:
+            {{- toYaml .Values.gatewayProxy.resources | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/bee/values.yaml
+++ b/charts/bee/values.yaml
@@ -367,6 +367,13 @@ clefSettings:
   password: clefbeesecret
   ## Use existing password (ignores previous keyPassword)
   # existingPasswordSecret:
+  resources: {}
+    # limits:
+    #   cpu: 1
+    #   memory: 1Gi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi 
 
 
 ## If enabled it will start gateway-proxy sidecar container that will be publicly exposed
@@ -414,3 +421,10 @@ gatewayProxy:
   #   value: 0.9374
   # - name: LOG_LEVEL
   #   value: info
+  resources: {}
+    # limits:
+    #   cpu: 1
+    #   memory: 1Gi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi 


### PR DESCRIPTION
hi

we usually set resource limits on all our containers on our cluster.

except there is no place to set such limits for the sidecar containers for clef & gateway proxy in the bee chart  :( 

i think this should add those as an optional parameter for people to configure.