### PR TITLE
chore: add support for traefik ingress for geth-swap

### DIFF
--- a/charts/geth-swap/Chart.yaml
+++ b/charts/geth-swap/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.7
+version: 0.3.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/geth-swap/templates/ingress.yaml
+++ b/charts/geth-swap/templates/ingress.yaml
@@ -1,6 +1,31 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "geth-swap.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- if eq .Values.ingress.class "traefik" -}}
+{{- $namespace := .Release.Namespace -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ $namespace }}
+spec:
+  routes:
+  {{- range .Values.ingress.hosts }}
+  {{-  $ingressHost := $fullName -}}
+  {{- if .domain }}
+  {{- $ingressHost = printf "%s.%s" $fullName .domain -}}
+  {{- end }}
+  {{- range .paths }}
+  - kind: Rule
+    match: Host({{ $ingressHost | quote }}) &&  PathPrefix({{ . | quote }})
+    services:
+    - kind: Service
+      name: {{ $fullName }}
+      namespace: {{ $namespace }}
+      port: {{ $svcPort }}
+  {{- end }}
+  {{- end }}
+{{- else -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
@@ -43,3 +68,4 @@ spec:
           {{- end }}
     {{- end }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
k3s 1.21 (we use it for CI tests) bumped traefik above 2.0. Traefik >2.0 switched from `Ingress` to `IngressRoute` CRD and this PR enables it for `geth-swap`