### PR TITLE
chore: remove wrong ttlSecondsAfterFinished

### DIFF
--- a/charts/beekeeper/Chart.yaml
+++ b/charts/beekeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 name: beekeeper
-version: 0.4.7
+version: 0.4.8
 description: Ethereum Swarm Beekeeper Helm chart for Kubernetes
 home: https://www.ethswarm.org
 icon: https://docs.ethswarm.org/img/swarm-logo-2.svg

--- a/charts/beekeeper/templates/job.yaml
+++ b/charts/beekeeper/templates/job.yaml
@@ -14,7 +14,6 @@ spec:
       labels:
         {{- include "beekeeper.selectorLabels" . | nindent 8 }}
     spec:
-      ttlSecondsAfterFinished: 86400
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
There were 2 `ttlSecondsAfterFinished: 86400` defined. Wrong one is removed with this PR