### PR TITLE
fix(geth-swap): support traefik v3 CRD api group

### DIFF
--- a/charts/geth-swap/Chart.yaml
+++ b/charts/geth-swap/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.1
+version: 0.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/geth-swap/templates/ingress.yaml
+++ b/charts/geth-swap/templates/ingress.yaml
@@ -3,7 +3,11 @@
 {{- $svcPort := .Values.service.port -}}
 {{- if eq .Values.ingress.class "traefik" -}}
 {{- $namespace := .Release.Namespace -}}
+{{- if .Capabilities.APIVersions.Has "traefik.io/v1alpha1" }}
+apiVersion: traefik.io/v1alpha1
+{{- else }}
 apiVersion: traefik.containo.us/v1alpha1
+{{- end }}
 kind: IngressRoute
 metadata:
   name: {{ $fullName }}

--- a/charts/geth-swap/templates/tests/test-connection.yaml
+++ b/charts/geth-swap/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "geth-swap.fullname" . }}:{{ .Values.service.port }}']
+      args: ['geth-swap:{{ .Values.service.port }}']
   restartPolicy: Never


### PR DESCRIPTION
Traefik v3 (k3s >= 1.33) removed the legacy `traefik.containo.us` API group,
breaking geth-swap installs with `ingress.class: traefik`:

    no matches for kind "IngressRoute" in version "traefik.containo.us/v1alpha1"

Pick `traefik.io/v1alpha1` via cluster capabilities when available, falling back
to the legacy group on older clusters. Backward compatible; chart bumped to 0.6.2.