### PR TITLE
fix(beekeeper): grant RBAC on traefik.io API group for Traefik v3

### DIFF
--- a/charts/beekeeper/Chart.yaml
+++ b/charts/beekeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 name: beekeeper
-version: 0.4.12
+version: 0.4.13
 description: Ethereum Swarm Beekeeper Helm chart for Kubernetes
 home: https://www.ethswarm.org
 icon: https://docs.ethswarm.org/img/swarm-logo-2.svg

--- a/charts/beekeeper/templates/clusterrole.yaml
+++ b/charts/beekeeper/templates/clusterrole.yaml
@@ -46,7 +46,7 @@ rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses","ingressroutes"]
   verbs: ["get", "list", "watch"]
-- apiGroups: ["traefik.containo.us"]
+- apiGroups: ["traefik.containo.us", "traefik.io"]
   resources: ["ingresses","ingressroutes"]
   verbs: ["get", "list", "watch"]
 


### PR DESCRIPTION
Traefik v3 (shipped by default in k3s >= 1.33) moved `IngressRoute` from the `traefik.containo.us` API group to `traefik.io`.

The beekeeper ClusterRole only grants `get`/`list`/`watch` on the legacy group, so on Traefik v3 clusters the beekeeper ServiceAccount cannot read IngressRoutes at all.

Adding `traefik.io` alongside the legacy entry in the same rule covers both v2 and v3: RBAC `apiGroups` is a list, and a rule is the cartesian product of `apiGroups` x `resources` x `verbs`, so no separate rule is needed and the legacy group keeps working.

The verbs are read-only, so this is no privilege escalation.

This is the RBAC counterpart to the resource-creation fix in #234 — that PR fixes the chart that *creates* the IngressRoute, this one fixes the chart that *reads* it. Those two were the only references to the legacy API group in the repo.

Chart version bumped 0.4.12 -> 0.4.13; `appVersion` unchanged.
