### PR TITLE
feat(beekeeper): add extraEnv and envFrom support

### DIFF
--- a/charts/beekeeper/Chart.yaml
+++ b/charts/beekeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 name: beekeeper
-version: 0.4.13
+version: 0.4.14
 description: Ethereum Swarm Beekeeper Helm chart for Kubernetes
 home: https://www.ethswarm.org
 icon: https://docs.ethswarm.org/img/swarm-logo-2.svg

--- a/charts/beekeeper/templates/cronjob.yaml
+++ b/charts/beekeeper/templates/cronjob.yaml
@@ -55,6 +55,13 @@ spec:
                   value: "{{ .Values.config.BZZ_TOKEN_ADDRESS }}"
                 - name: BEEKEEPER_ETH_ACCOUNT
                   value: "{{ .Values.config.ETH_ACCOUNT }}"
+                {{- with .Values.extraEnv }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              {{- with .Values.envFrom }}
+              envFrom:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               command:
                 {{- range .Values.config.command }}
                 - {{ . }}

--- a/charts/beekeeper/templates/job.yaml
+++ b/charts/beekeeper/templates/job.yaml
@@ -41,6 +41,13 @@ spec:
               value: "{{ .Values.config.BZZ_TOKEN_ADDRESS }}"
             - name: BEEKEEPER_ETH_ACCOUNT
               value: "{{ .Values.config.ETH_ACCOUNT }}"
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -72,6 +79,13 @@ spec:
               value: "{{ .Values.config.BZZ_TOKEN_ADDRESS }}"
             - name: BEEKEEPER_ETH_ACCOUNT
               value: "{{ .Values.config.ETH_ACCOUNT }}"
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             {{- range .Values.config.command }}
             - {{ . }}

--- a/charts/beekeeper/values.yaml
+++ b/charts/beekeeper/values.yaml
@@ -31,6 +31,30 @@ resources: {}
 
 nodeSelector: {}
 
+## Additional environment variables for the beekeeper container.
+## Use this to supply secrets rather than putting them in config.command,
+## where they end up readable in the Job/CronJob spec.
+##
+## Beekeeper reads any flag from the environment as BEEKEEPER_<FLAG>, with
+## dashes replaced by underscores, so --wallet-key can be provided as
+## BEEKEEPER_WALLET_KEY instead of being passed on the command line.
+##
+## Example:
+# extraEnv:
+#   - name: BEEKEEPER_WALLET_KEY
+#     valueFrom:
+#       secretKeyRef:
+#         name: beekeeper-wallet-key
+#         key: walletKey
+extraEnv: []
+
+## Populate environment variables from Secrets or ConfigMaps.
+## Example:
+# envFrom:
+#   - secretRef:
+#       name: beekeeper-wallet-key
+envFrom: []
+
 config:
   command: ["beekeeper", "check"]
   parallelism: 1


### PR DESCRIPTION
The beekeeper chart renders a fixed `env` list with no way to inject anything else, so secrets have to be passed on the command line through `config.command`. Anything passed that way is stored verbatim in the Job/CronJob spec, readable by anyone who can read those objects in the namespace.

The node-funder deployments hit this directly — they pass a funding wallet private key as `--wallet-key`.

Beekeeper already binds every flag to an environment variable (viper, prefix `beekeeper`, dashes → underscores), so `--wallet-key` can be supplied as `BEEKEEPER_WALLET_KEY` with no beekeeper change. This adds the chart plumbing:

```yaml
extraEnv:
  - name: BEEKEEPER_WALLET_KEY
    valueFrom:
      secretKeyRef:
        name: beekeeper-wallet-key
        key: walletKey
```

`extraEnv` and `envFrom` are applied to the CronJob container and to both Job containers (`init-ping` and main), so behaviour is identical in either mode.

**Backwards compatible:** both default to `[]` and are wrapped in `with`, so a chart rendered without them is byte-identical to before. Verified with `helm template` on default values — no stray keys. Also verified the secret-backed and `envFrom` variants render valid YAML in both `job.yaml` paths.

Chart version 0.4.13 → 0.4.14.